### PR TITLE
Warn if InfluxDbMeasurement.Builder is invalid

### DIFF
--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/DropwizardTransformer.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/DropwizardTransformer.java
@@ -334,11 +334,11 @@ public class DropwizardTransformer {
         .putTags(tags)
         .tryPutFields(fields, e -> log.warn(e.getMessage()));
 
-    if (builder.isValid()) {
+    if (!builder.isValid()) {
       log.warn("Measurement has no valid fields: {}", groupKey.measurement());
-      return Optional.of(builder.build());
+      return Optional.empty();
     }
 
-    return Optional.empty();
+    return Optional.of(builder.build());
   }
 }


### PR DESCRIPTION
## What

Modifies the conditional logic to log a warning if the InfluxDbMeasurement.Builder is _invalid_.

## Why

Fixes #1. 

h/t @arteam 👍