### PR TITLE
Serialize string and primitive collections

### DIFF
--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -161,27 +161,25 @@ public abstract class InfluxDbMeasurement {
 
         StringBuilder builder = new StringBuilder();
         for (final ? val: value) {
-          fieldToString(val)
-            .map(s -> builder.add(key, s))
-            .orElseThrow(() -> new IllegalArgumentException(
+          try {
+            fieldToString(val).ifPresent(s -> builder.add(key, s));
+          } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
               String.format(
                 "InfluxDbMeasurement collection field '%s' must contain only Strings and primitives: '%s'",
-                key,
-                val.toString()
-              )
-            ));
+                key, val));
+          }
         }
         fields.put(key, builder.build());
       } else {
-        fieldToString(value)
-          .map(s -> fields.put(key, s))
-          .orElseThrow(() -> new IllegalArgumentException(
+        try {
+          fieldToString(value).ifPresent(s -> fields.put(key, s))
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException(
             String.format(
-              "InfluxDbMeasurement field '%s' must be String, primitive, or Collection: '%s'",
-              key,
-              value
-            )
-          ));
+              "InfluxDbMeasurement field '%s' must be a String, primitive, or Collection: '%s'",
+              key, value));
+        }
       }
 
       return this;
@@ -202,6 +200,9 @@ public abstract class InfluxDbMeasurement {
         return Optional.of(String.format("%di", ((Number) value).longValue()));
       } else if (value instanceof String || value instanceof Boolean) {
         return Optional.of(value.toString());
+      } else {
+        throw new IllegalArgumentException(
+          String.format("invalid field '%s'", value));
       }
 
       return Optional.empty();

--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -164,7 +165,10 @@ public abstract class InfluxDbMeasurement {
 
         try {
           // validate that all the collection values are strings or primitives.
-          collection.stream().map(this::fieldToString);
+          final Iterator iterator = collection.iterator();
+          while (iterator.hasNext()) {
+            fieldToString(iterator.next());
+          }
           fields.put(key, collection.toString());
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException(

--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -156,14 +156,10 @@ public abstract class InfluxDbMeasurement {
     public <T> Builder putField(final String key, final T value) {
       if (value instanceof Collection<?>) {
         final Collection collection = (Collection) value;
-        if (collection.isEmpty()) {
-          return this;
-        }
-
-        final String collString = validatePrimitiveCollection(key, collection);
+        final String collString = validatedPrimitiveCollection(key, collection);
         fields.put(key, collString);
       } else if (value != null) {
-        final Optional<String> fieldString = validatePrimitiveField(key, value);
+        final Optional<String> fieldString = validatedPrimitiveField(key, value);
         fieldString.ifPresent(s -> fields.put(key, s));
       }
 
@@ -176,7 +172,7 @@ public abstract class InfluxDbMeasurement {
      * @return the collection as a string, if valid.
      * @throws IllegalArgumentException if any collection value is not a string or primitive.
      */
-    private static String validatePrimitiveCollection(final String key, final Collection collection) {
+    private static String validatedPrimitiveCollection(final String key, final Collection collection) {
       try {
         collection.forEach(InfluxDbMeasurement.Builder::fieldToString);
         return collection.toString();
@@ -197,7 +193,7 @@ public abstract class InfluxDbMeasurement {
 
      * @throws IllegalArgumentException if the field is not a string or primitive.
      */
-    private static Optional<String> validatePrimitiveField(final String key, final Object value) {
+    private static Optional<String> validatedPrimitiveField(final String key, final Object value) {
       try {
         return fieldToString(value);
       } catch (IllegalArgumentException e) {

--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -105,9 +105,6 @@ public abstract class InfluxDbMeasurement {
 
     /**
      * Adds all key-value pairs to the tags map.
-     *
-     * @param items
-     * @return
      */
     public Builder putTags(final Map<String, String> items) {
       tags.putAll(items);

--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -3,13 +3,14 @@ package com.kickstarter.dropwizard.metrics.influxdb;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -20,8 +21,9 @@ import static java.util.stream.Collectors.toList;
  */
 @AutoValue
 public abstract class InfluxDbMeasurement {
-  private static final List<Class> VALID_FIELD_CLASSES = ImmutableList.of(
-    Number.class, Character.class, String.class, Boolean.class
+  private static final Set<Class> VALID_FIELD_CLASSES = ImmutableSet.of(
+    Boolean.class, Byte.class, Character.class, Double.class, Float.class,
+    Integer.class, Long.class, Short.class, String.class
   );
 
   public abstract String name();
@@ -152,8 +154,8 @@ public abstract class InfluxDbMeasurement {
     /**
      * Adds the given key-value pair to the fields map.
      *
-     * @throws IllegalArgumentException if any value is not a String, primitive,
-     *         or Collection of Strings and primitives.
+     * @throws IllegalArgumentException if any value is not one of:
+     *         null, String, primitive, or a Collection of Strings and primitives.
      */
     public <T> Builder putField(final String key, final T value) {
       if (value instanceof Collection<?>) {
@@ -169,10 +171,10 @@ public abstract class InfluxDbMeasurement {
     }
 
     /**
-     * Validates that the collection only contains Strings and primitives.
+     * Validates that the collection only contains null values, Strings, and primitives.
      *
      * @return the collection as a string, if valid.
-     * @throws IllegalArgumentException if any collection value is not a string or primitive.
+     * @throws IllegalArgumentException if any collection value is not a null value, string or primitive.
      */
     private static String validatedPrimitiveCollection(final String key, final Collection collection) {
       for (final Object value : collection) {
@@ -190,12 +192,12 @@ public abstract class InfluxDbMeasurement {
     }
 
     /**
-     * Validates that the field is a String or primitive.
+     * Validates that the field is a null value, String, or primitive.
      *
-     * @return true if the field is a String or primitive.
+     * @return true if the field is a null value, String, or primitive.
      */
     private static <T> boolean isValidField(final T value) {
-      return VALID_FIELD_CLASSES.stream().anyMatch(klass -> klass.isInstance(value));
+      return value == null || VALID_FIELD_CLASSES.contains(value.getClass());
     }
 
     /**

--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -21,7 +21,7 @@ import static java.util.stream.Collectors.toList;
 @AutoValue
 public abstract class InfluxDbMeasurement {
   private static final List<Class> VALID_FIELD_CLASSES = ImmutableList.of(
-    Float.class, Double.class, Integer.class, Long.class, String.class, Boolean.class
+    Number.class, Character.class, String.class, Boolean.class
   );
 
   public abstract String name();
@@ -217,9 +217,10 @@ public abstract class InfluxDbMeasurement {
         if (!Double.isNaN(d) && !Double.isInfinite(d)) {
           return Optional.of(String.valueOf(d));
         }
-      } else if (value instanceof Integer || value instanceof Long) {
+      } else if (value instanceof Number) {
+        // Serialize Byte, Short, Integer, and Long values as integers.
         return Optional.of(String.format("%di", ((Number) value).longValue()));
-      } else if (value instanceof String || value instanceof Boolean) {
+      } else if (value instanceof String || value instanceof Character || value instanceof Boolean) {
         return Optional.of(value.toString());
       } else {
         throw new IllegalArgumentException(

--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurement.java
@@ -127,7 +127,7 @@ public abstract class InfluxDbMeasurement {
     }
 
     /**
-     * Adds all key-value pairs to the fields map.
+     * Adds all key-value pairs to the fields map; null, NaN, and +-Inf values are dropped.
      *
      * @throws IllegalArgumentException if any value is not a String or primitive.
      */
@@ -137,7 +137,7 @@ public abstract class InfluxDbMeasurement {
     }
 
     /**
-     * Adds all key-value pairs to the fields map.
+     * Adds all key-value pairs to the fields map; null, NaN, and +-Inf values are dropped.
      */
     public <T> Builder tryPutFields(final Map<String, T> fields,
                                     final Consumer<IllegalArgumentException> exceptionHandler) {
@@ -152,7 +152,7 @@ public abstract class InfluxDbMeasurement {
     }
 
     /**
-     * Adds the given key-value pair to the fields map.
+     * Adds the given key-value pair to the fields map if it is not one of: null, NaN, +-Inf.
      *
      * @throws IllegalArgumentException if any value is not one of:
      *         null, String, primitive, or a Collection of Strings and primitives.

--- a/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
+++ b/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
@@ -245,6 +245,21 @@ public class InfluxDbMeasurementTest {
   }
 
   @Test
+  public void testBuilder_PutStringAndPrimitiveCollection() {
+    final InfluxDbMeasurement measurement = new InfluxDbMeasurement.Builder("Measurement", 90210L)
+      .putField("eating", ImmutableList.of("a", "c", "d"))
+      .build();
+
+    assertEquals("should add Collection field to the measurement",
+      InfluxDbMeasurement.create("Measurement", ImmutableMap.of(), ImmutableMap.of("eating", "[a, c, d]"), 90210L),
+      measurement);
+  }
+
+  @Test
+  public void testBuilder_PutNonStringOrPrimitiveCollection() {
+  }
+
+  @Test
   public void testBuilder_PutNonStringOrPrimitiveField() {
     try {
       new InfluxDbMeasurement.Builder("Measurement", 90210L).putField("val", Arrays.asList(1, 2, 3));

--- a/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
+++ b/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
@@ -247,26 +247,34 @@ public class InfluxDbMeasurementTest {
   @Test
   public void testBuilder_PutStringAndPrimitiveCollection() {
     final InfluxDbMeasurement measurement = new InfluxDbMeasurement.Builder("Measurement", 90210L)
-      .putField("eating", ImmutableList.of("a", "c", "d"))
+      .putField("eating", Arrays.asList(1, 2, 3))
       .build();
 
     assertEquals("should add Collection field to the measurement",
-      InfluxDbMeasurement.create("Measurement", ImmutableMap.of(), ImmutableMap.of("eating", "[a, c, d]"), 90210L),
+      InfluxDbMeasurement.create("Measurement", ImmutableMap.of(), ImmutableMap.of("eating", "[1, 2, 3]"), 90210L),
       measurement);
   }
 
   @Test
   public void testBuilder_PutNonStringOrPrimitiveCollection() {
+    try {
+      new InfluxDbMeasurement.Builder("Measurement", 90210L)
+        .putField("val", Arrays.asList(ImmutableMap.of("okay", "then")));
+      fail("Expected an Exception when adding a non-String or -primitive field");
+    } catch (final Exception thrown) {
+      assertEquals("Expected an IllegalArgumentException", IllegalArgumentException.class, thrown.getClass());
+      assertEquals("InfluxDbMeasurement collection field 'val' must contain only Strings and primitives: '{\"okay\": \"then\"}'", thrown.getMessage());
+    }
   }
 
   @Test
   public void testBuilder_PutNonStringOrPrimitiveField() {
     try {
-      new InfluxDbMeasurement.Builder("Measurement", 90210L).putField("val", Arrays.asList(1, 2, 3));
+      new InfluxDbMeasurement.Builder("Measurement", 90210L).putField("val", ImmutableMap.of("okay", "then"));
       fail("Expected an Exception when adding a non-String or -primitive field");
     } catch (final Exception thrown) {
       assertEquals("Expected an IllegalArgumentException", IllegalArgumentException.class, thrown.getClass());
-      assertEquals("InfluxDbMeasurement field 'val' must be String or primitive: [1, 2, 3]", thrown.getMessage());
+      assertEquals("InfluxDbMeasurement field 'val' must be a, String, primitive, or Collection: {\"okay\": \"then\"}", thrown.getMessage());
     }
   }
   

--- a/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
+++ b/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
@@ -259,7 +259,7 @@ public class InfluxDbMeasurementTest {
     try {
       new InfluxDbMeasurement.Builder("Measurement", 90210L)
         .putField("val", Arrays.asList(ImmutableMap.of("okay", "then")));
-      fail("Expected an Exception when adding a non-String or -primitive field");
+      fail("Expected an Exception when adding a non-String, -primitive, or Collection field");
     } catch (final Exception thrown) {
       assertEquals("Expected an IllegalArgumentException", IllegalArgumentException.class, thrown.getClass());
       assertEquals("InfluxDbMeasurement collection field 'val' must contain " +

--- a/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
+++ b/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/InfluxDbMeasurementTest.java
@@ -2,7 +2,6 @@ package com.kickstarter.dropwizard.metrics.influxdb;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -263,7 +262,8 @@ public class InfluxDbMeasurementTest {
       fail("Expected an Exception when adding a non-String or -primitive field");
     } catch (final Exception thrown) {
       assertEquals("Expected an IllegalArgumentException", IllegalArgumentException.class, thrown.getClass());
-      assertEquals("InfluxDbMeasurement collection field 'val' must contain only Strings and primitives: '{\"okay\": \"then\"}'", thrown.getMessage());
+      assertEquals("InfluxDbMeasurement collection field 'val' must contain " +
+        "only Strings and primitives: invalid field '{okay=then}'", thrown.getMessage());
     }
   }
 
@@ -274,7 +274,8 @@ public class InfluxDbMeasurementTest {
       fail("Expected an Exception when adding a non-String or -primitive field");
     } catch (final Exception thrown) {
       assertEquals("Expected an IllegalArgumentException", IllegalArgumentException.class, thrown.getClass());
-      assertEquals("InfluxDbMeasurement field 'val' must be a, String, primitive, or Collection: {\"okay\": \"then\"}", thrown.getMessage());
+      assertEquals("InfluxDbMeasurement field 'val' must be a String, primitive, or Collection: " +
+        "invalid field '{okay=then}'", thrown.getMessage());
     }
   }
   
@@ -283,9 +284,9 @@ public class InfluxDbMeasurementTest {
     final ArrayList<Exception> exceptions = new ArrayList<>();
 
     new InfluxDbMeasurement.Builder("Measurement", 90210L).tryPutFields(ImmutableMap.of(
-      "a", ImmutableSet.of(),
+      "a", ImmutableMap.of("well", "okay"),
       "c", "d",
-      "e", Arrays.asList(1, 2, 3)
+      "e", ImmutableMap.of("not", 1, "good", 2)
     ), exceptions::add);
 
     assertEquals("should catch two exceptions", 2, exceptions.size());
@@ -293,8 +294,8 @@ public class InfluxDbMeasurementTest {
     assertEquals("should catch IllegalArgumentExceptions", IllegalArgumentException.class, exceptions.get(1).getClass());
     assertEquals("should describe the invalid key-value pair",
       ImmutableList.of(
-        "InfluxDbMeasurement field 'a' must be String or primitive: []",
-        "InfluxDbMeasurement field 'e' must be String or primitive: [1, 2, 3]"
+        "InfluxDbMeasurement field 'a' must be a String, primitive, or Collection: invalid field '{well=okay}'",
+        "InfluxDbMeasurement field 'e' must be a String, primitive, or Collection: invalid field '{not=1, good=2}'"
       ),
       exceptions.stream().map(Exception::getMessage).collect(toList())
     );

--- a/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/DropwizardTransformerTest.java
+++ b/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/DropwizardTransformerTest.java
@@ -430,11 +430,13 @@ public class DropwizardTransformerTest {
     final Map<String, Object> objFields = ImmutableMap.of(
       "some", true,
       "bad", Arrays.asList(1, 2, 3),
-      "fields", 5
+      "fields", 5,
+      "NOW", ImmutableMap.of("ha", "ha")
     );
 
     final Map<String, String> strFields = ImmutableMap.of(
       "some", "true",
+      "bad", "[1, 2, 3]",
       "fields", "5i"
     );
 
@@ -451,7 +453,7 @@ public class DropwizardTransformerTest {
 
     final Map<String, Object> objFields = ImmutableMap.of(
       "all", Float.NaN,
-      "bad", Arrays.asList(1, 2, 3),
+      "bad", ImmutableMap.of("oh", "no"),
       "fields", Float.NaN
     );
 


### PR DESCRIPTION
## What

Permits string and primitive collections as serializable measurement values.

## Why

Fixes #2 — allows the InfluxDB reporter to report the names of app threads that are deadlocked.

I'm being cautious here and not allowing arbitrary collection objects, but leaving the serialization details up to the collection's `toString` method — we don't need to filter out NaN values or postfix integers as e.g. `1i` here, since we're sending these collections as strings instead of influxdb integers/floats/doubles.

## Who

Assigning assorted java humans

h/t. @arteam :wave: