### PR TITLE
TaggedPattern: Fix NPE when using optional maching group

### DIFF
--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/TaggedPattern.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/TaggedPattern.java
@@ -59,6 +59,7 @@ public class TaggedPattern {
     final Matcher matcher = compiledPattern.matcher(input);
     if (matcher.matches()) {
       return Optional.of(tagKeys.stream()
+        .filter(tag -> matcher.group(tag) != null)
         .filter(tag -> !matcher.group(tag).isEmpty())
         .collect(toMap(Function.identity(), matcher::group)));
     }

--- a/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/TaggedPatternTest.java
+++ b/src/test/java/com/kickstarter/dropwizard/metrics/influxdb/transformer/TaggedPatternTest.java
@@ -45,4 +45,15 @@ public class TaggedPatternTest {
       untaggedPattern.tags(".hello.anything.whatever")
     );
   }
+
+  @Test
+  public void testTags_optionalGroup() {
+    final TaggedPattern optionalPattern = new TaggedPattern(
+      "\\.hello\\.(?<action>[A-Za-z]+)\\.(?<number>[0-9]+)?\\.?(?<model>.*)",
+      "action", "number", "model");
+    assertEquals(
+      Optional.of(ImmutableMap.of("action", "move", "model", "foobar")),
+      optionalPattern.tags(".hello.move.foobar")
+    );
+  }
 }


### PR DESCRIPTION
Using an optional matching group in a template regular expression throws a `NullPointerException` because `matcher.group(groupName)` returns **null**.