### PR TITLE
Properly close responses returned by POST requests

### DIFF
--- a/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/io/InfluxDbHttpWriter.java
+++ b/src/main/java/com/kickstarter/dropwizard/metrics/influxdb/io/InfluxDbHttpWriter.java
@@ -8,6 +8,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.Range;
 
@@ -32,7 +33,16 @@ public class InfluxDbHttpWriter implements InfluxDbWriter {
 
   @Override
   public void writeBytes(final byte[] bytes) {
-    influxLines.request().post(Entity.entity(bytes, MediaType.APPLICATION_OCTET_STREAM_TYPE));
+    Response response = null;
+    try {
+        response = influxLines.request()
+          .post(Entity.entity(bytes, MediaType.APPLICATION_OCTET_STREAM_TYPE));
+    }
+    finally {
+      if (response != null) {
+        response.close();
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
The HTTP InfluxDB writer is leaking connections by not closing the response objects returned by calls to the `post()` method.

After a while the connection pool cannot create new connections and throws the following exception:
```log
javax.ws.rs.ProcessingException: org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
	at io.dropwizard.client.DropwizardApacheConnector.apply(DropwizardApacheConnector.java:109)
	at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:252)
	at org.glassfish.jersey.client.JerseyInvocation$1.call(JerseyInvocation.java:684)
	at org.glassfish.jersey.client.JerseyInvocation$1.call(JerseyInvocation.java:681)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:228)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:444)
	at org.glassfish.jersey.client.JerseyInvocation.invoke(JerseyInvocation.java:681)
	at org.glassfish.jersey.client.JerseyInvocation$Builder.method(JerseyInvocation.java:437)
	at org.glassfish.jersey.client.JerseyInvocation$Builder.post(JerseyInvocation.java:343)
	at com.kickstarter.dropwizard.metrics.influxdb.io.InfluxDbHttpWriter.writeBytes(InfluxDbHttpWriter.java:33)
	at com.kickstarter.dropwizard.metrics.influxdb.io.Sender.send(Sender.java:61)
	at com.kickstarter.dropwizard.metrics.influxdb.InfluxDbMeasurementReporter.report(InfluxDbMeasurementReporter.java:75)
	at com.codahale.metrics.ScheduledReporter.report(ScheduledReporter.java:162)
	at com.codahale.metrics.ScheduledReporter$1.run(ScheduledReporter.java:117)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:286)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:263)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:190)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107)
	at io.dropwizard.client.DropwizardApacheConnector.apply(DropwizardApacheConnector.java:87)
	... 22 more
```